### PR TITLE
Backend developer tech test

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,3 @@
 django<4
 djangorestframework==3.14.0
+parameterized==0.8.1

--- a/backend/ths/listings/serializers.py
+++ b/backend/ths/listings/serializers.py
@@ -1,9 +1,15 @@
 from rest_framework import serializers
 
-from .models import Listing
+from .models import Assignment, Listing
 
 
 class ListingSerializer(serializers.ModelSerializer):
     class Meta:
         model = Listing
         fields = ["first_name", "last_name", "pets", "assignments"]
+
+
+class AssignmentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Assignment
+        fields = ["start_date", "end_date", "listing"]

--- a/backend/ths/listings/tests.py
+++ b/backend/ths/listings/tests.py
@@ -1,8 +1,11 @@
 from datetime import date
+from unittest.mock import patch
 
+from parameterized import parameterized
 from rest_framework import status
 from rest_framework.test import APITestCase
-from .models import Listing, Assignment
+
+from .models import Assignment, Listing
 
 
 class ListingList(APITestCase):
@@ -43,3 +46,174 @@ class ListingList(APITestCase):
                 },
             ],
         )
+
+
+class AssignmentCreate(APITestCase):
+    ENDPOINT = "/listings/assignments/"
+
+    def setUp(self):
+        self.listing = Listing.objects.create(first_name="Ross", last_name="Geller")
+
+    def test_get_405(self):
+        # GET should not be allowed on the endpoint
+        response = self.client.get(self.ENDPOINT)
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    @patch("listings.views.date", fromisoformat=date.fromisoformat)
+    def test_create(self, date_mock):
+        date_mock.today.return_value = date(2023, 2, 5)
+        # Future assignment creation happy path
+        data = {
+            "start_date": date(2023, 2, 10),
+            "end_date": date(2023, 2, 17),
+            "listing": self.listing.pk,
+        }
+        response = self.client.post(self.ENDPOINT, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Check response data
+        response_data = response.json()
+        self.assertEqual(str(data["start_date"]), response_data["start_date"])
+        self.assertEqual(str(data["end_date"]), response_data["end_date"])
+        self.assertEqual(data["listing"], response_data["listing"])
+
+    @patch("listings.views.date", fromisoformat=date.fromisoformat)
+    def test_bad_listing_id(self, date_mock):
+        date_mock.today.return_value = date(2023, 2, 5)
+
+        data = {
+            "start_date": date(2023, 2, 10),
+            "end_date": date(2023, 2, 17),
+            "listing": "foo",  # NB invalid pk
+        }
+        response = self.client.post(self.ENDPOINT, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch("listings.views.date", fromisoformat=date.fromisoformat)
+    def test_missing_listing_id(self, date_mock):
+        date_mock.today.return_value = date(2023, 2, 5)
+
+        data = {
+            "start_date": date(2023, 2, 10),
+            "end_date": date(2023, 2, 17),
+            # NB missing pk
+        }
+        response = self.client.post(self.ENDPOINT, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @parameterized.expand(
+        [
+            [
+                date(2023, 2, 3),
+                date(2023, 2, 11),
+                status.HTTP_400_BAD_REQUEST,
+            ],
+            [
+                date(2023, 2, 5),
+                date(2023, 2, 11),
+                status.HTTP_400_BAD_REQUEST,
+            ],
+            [
+                date(2023, 2, 6),
+                date(2023, 2, 11),
+                status.HTTP_201_CREATED,
+            ],
+            [
+                date(2023, 12, 25),
+                date(2023, 12, 31),
+                status.HTTP_201_CREATED,
+            ],
+        ]
+    )
+    @patch("listings.views.date", fromisoformat=date.fromisoformat)
+    def test_start_tomorrow_or_later_required(
+        self, start_date, end_date, expected, date_mock
+    ):
+        date_mock.today.return_value = date(2023, 2, 5)
+
+        data = {
+            "start_date": start_date,
+            "end_date": end_date,
+            "listing": self.listing.pk,
+        }
+        response = self.client.post(self.ENDPOINT, data)
+        self.assertEqual(response.status_code, expected)
+
+    @parameterized.expand(
+        [
+            [
+                date(2023, 3, 28),
+                date(2023, 4, 12),
+            ],  # overlaps start of proposed dates
+            [
+                date(2023, 4, 25),
+                date(2023, 5, 11),
+            ],  # overlaps end of proposed dates
+            [
+                date(2023, 3, 20),
+                date(2023, 4, 29),
+            ],  # encomposses whole proposed dates
+            [
+                date(2023, 4, 10),
+                date(2023, 4, 12),
+            ],  # completely within proposed dates
+        ]
+    )
+    @patch("listings.views.date", fromisoformat=date.fromisoformat)
+    def test_no_overlap_this_listing(self, existing_start, existing_end, date_mock):
+        date_mock.today.return_value = date(2023, 2, 5)
+
+        # create existing assignment according to parameterised data
+        self.listing.assignments.create(
+            start_date=existing_start, end_date=existing_end
+        )
+
+        data = {
+            "start_date": date(2023, 3, 30),
+            "end_date": date(2023, 4, 27),
+            "listing": self.listing.pk,
+        }
+        response = self.client.post(self.ENDPOINT, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @parameterized.expand(
+        [
+            [
+                date(2023, 3, 28),
+                date(2023, 4, 12),
+            ],  # overlaps start
+            [
+                date(2023, 4, 25),
+                date(2023, 5, 11),
+            ],  # overlaps end
+            [
+                date(2023, 3, 20),
+                date(2023, 4, 29),
+            ],  # encomposses whole
+            [
+                date(2023, 4, 10),
+                date(2023, 4, 12),
+            ],  # within proposed range
+        ]
+    )
+    @patch("listings.views.date", fromisoformat=date.fromisoformat)
+    def test_assignment_no_overlap_ignore_other_listings(
+        self, existing_start, existing_end, date_mock
+    ):
+        # Assignments on other listings should not affect ours
+        date_mock.today.return_value = date(2023, 2, 5)
+
+        # Create assignment on other listing according to parameterised data
+        other_listing = Listing.objects.create(first_name="Grumpy", last_name="Cat")
+        other_listing.assignments.create(
+            start_date=existing_start, end_date=existing_end
+        )
+
+        # Assignment date checks should be for this listing only
+        data = {
+            "start_date": date(2023, 3, 30),
+            "end_date": date(2023, 4, 27),
+            "listing": self.listing.pk,
+        }
+        response = self.client.post(self.ENDPOINT, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/backend/ths/listings/urls.py
+++ b/backend/ths/listings/urls.py
@@ -1,5 +1,8 @@
 from django.urls import path
 
-from .views import ListingList
+from .views import AssigmentCreate, ListingList
 
-urlpatterns = [path("", ListingList.as_view())]
+urlpatterns = [
+    path("", ListingList.as_view()),
+    path("assignments/", AssigmentCreate.as_view()),
+]

--- a/backend/ths/listings/views.py
+++ b/backend/ths/listings/views.py
@@ -9,7 +9,7 @@ from .serializers import AssignmentSerializer, ListingSerializer
 
 class ListingList(generics.ListAPIView):
     serializer_class = ListingSerializer
-    queryset = Listing.objects.all()
+    queryset = Listing.objects.all().prefetch_related("assignments", "pets")
 
 
 class AssigmentCreate(generics.CreateAPIView):

--- a/backend/ths/listings/views.py
+++ b/backend/ths/listings/views.py
@@ -1,9 +1,38 @@
+from datetime import date
+
+from django.http import HttpResponseBadRequest
 from rest_framework import generics
 
 from .models import Listing
-from .serializers import ListingSerializer
+from .serializers import AssignmentSerializer, ListingSerializer
 
 
 class ListingList(generics.ListAPIView):
     serializer_class = ListingSerializer
     queryset = Listing.objects.all()
+
+
+class AssigmentCreate(generics.CreateAPIView):
+    serializer_class = AssignmentSerializer
+
+    def create(self, request, *args, **kwargs):
+        start_date = request.data.get("start_date")
+        end_date = request.data.get("end_date")
+        try:
+            # DRF defaults to iso format
+            if date.fromisoformat(start_date) <= date.today():
+                raise ValueError
+        except (TypeError, ValueError):
+            return HttpResponseBadRequest()
+
+        try:
+            listing = Listing.objects.get(pk=request.data.get("listing"))
+            if listing.assignments.filter(
+                end_date__gte=start_date,
+                start_date__lte=end_date,
+            ).exists():
+                raise ValueError
+        except (Listing.DoesNotExist, ValueError):
+            return HttpResponseBadRequest()
+
+        return super().create(request, *args, **kwargs)

--- a/backend/ths/listings/views.py
+++ b/backend/ths/listings/views.py
@@ -18,6 +18,8 @@ class AssigmentCreate(generics.CreateAPIView):
     def create(self, request, *args, **kwargs):
         start_date = request.data.get("start_date")
         end_date = request.data.get("end_date")
+
+        # Ensure assignments are in the future
         try:
             # DRF defaults to iso format
             if date.fromisoformat(start_date) <= date.today():
@@ -25,6 +27,7 @@ class AssigmentCreate(generics.CreateAPIView):
         except (TypeError, ValueError):
             return HttpResponseBadRequest()
 
+        # Refuse overlapping assingments
         try:
             listing = Listing.objects.get(pk=request.data.get("listing"))
             if listing.assignments.filter(


### PR DESCRIPTION
Used prefetch_related to address the slowdown on scaling. Here, the pets and assignments reverse relations are fetched at the same time as the listing, so when we access the related objects in code there are no further database hits as the data is prefetched into local Python objects.

An example:

```
# without prefetch_related
for listing in Listing.objects.all():
    for assignment in listing.assignments.all():
        <using each assignment object in this loop causes individual hit on the d>
```


```
# with prefetch_related
for listing in Listing.objects.prefetch_related('assignments'):
    for assignment in listing.assignments.all():
        <this for loop causes no additional db queries>
```

In addition to this we could use DRF pagination classes together with a Javascript frontend framework (e.g. React, Vue) to implement lazy (infinite) pagination for an enhanced user experience rather than return and render 1000 results all at once. The pagination classes (with various options) add 'prev', 'next' URLs to the response so that the frontend can request the appropriate next page of data.

However, the pagination suggestion is in addition to the prefetch of reverse relationship data which is a very important consideration when scaling.

@EilidhHendry @alasdairnicol 