### PR TITLE
added pagination to listings endpoint

### DIFF
--- a/backend/ths/listings/views.py
+++ b/backend/ths/listings/views.py
@@ -6,4 +6,6 @@ from .serializers import ListingSerializer
 
 class ListingList(generics.ListAPIView):
     serializer_class = ListingSerializer
-    queryset = Listing.objects.all()
+
+    def get_queryset(self):
+        return Listing.objects.all().prefetch_related("pets", "assignments")

--- a/backend/ths/ths/settings.py
+++ b/backend/ths/ths/settings.py
@@ -125,3 +125,8 @@ STATIC_URL = "/static/"
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+REST_FRAMEWORK = {
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 2,  # or 100 depending on your needs
+}


### PR DESCRIPTION
**Summary**
This PR aims to add in fix to ensure that the listing endpoint is able to scale properly with large amounts of data. To achieve this a paginated response has been introduced. This is to ensure that all listings are not returned at once. I have added an extra suggestion in the "note for reviewers" sections.

**Changes**

- Change 1: added  REST_FRAMEWORK config to Django settings.
- Change 2: modified the listings view with with a get_queryset method.

**Testing**
Added the below tests:

- test_create_assignment_200

Linked Issues
N/A

Notes for Reviewers
Another suggestion, which could ensure that the listing endpoint scales properly are as follows:

- Caching of heavy repeated requests, using Redis.