### PR TITLE
[EPolden]: Implement Deep Linking to Listing Details

### DIFF
--- a/ths-test-app/src/App.tsx
+++ b/ths-test-app/src/App.tsx
@@ -8,6 +8,7 @@ import {
 import { useLogger } from '@react-navigation/devtools';
 
 import { Navigation } from './navigation';
+import { useDeepLinking } from './hooks/useDeepLinking';
 
 SplashScreen.preventAutoHideAsync();
 
@@ -26,6 +27,7 @@ export function App() {
   const navigationRef = useNavigationContainerRef();
 
   useLogger(navigationRef);
+  useDeepLinking(navigationRef, isLoggedIn);
 
   useEffect(() => {
       async function enableMocking() {

--- a/ths-test-app/src/helpers/getAnimalDisplay.ts
+++ b/ths-test-app/src/helpers/getAnimalDisplay.ts
@@ -1,0 +1,24 @@
+type Animal = { name: string; count: number };
+
+function getAnimalIcons(animalName: string): string {
+  const icons: Record<string, string> = {
+    dog: "🐕",
+    cat: "🐈",
+    reptile: "🦎",
+    horse: "🐴",
+    fish: "🐠",
+    poultry: "🐔",
+    "small pet": "🐹",
+    "farm animal": "🐄",
+  };
+
+  return icons[animalName.toLowerCase()];
+}
+
+export function getAnimalDisplay(animals: Animal[]) {
+  const totalCount = animals.reduce((sum, animal) => sum + animal.count, 0);
+  const iconStrings = animals.map((animal) => getAnimalIcons(animal.name));
+  const icons = iconStrings.join(' ');
+
+  return { totalCount, icons };
+}

--- a/ths-test-app/src/hooks/__tests__/useDeepLinking.test.ts
+++ b/ths-test-app/src/hooks/__tests__/useDeepLinking.test.ts
@@ -1,0 +1,124 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useDeepLinking } from '../useDeepLinking';
+import * as Linking from 'expo-linking';
+import { StackActions, NavigationContainerRef } from '@react-navigation/native';
+import type { ParsedURL } from 'expo-linking';
+
+jest.mock('expo-linking');
+
+const mockLinking = Linking as jest.Mocked<typeof Linking>;
+const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
+global.fetch = mockFetch;
+
+type NavigationRef = NavigationContainerRef<ReactNavigation.RootParamList>;
+
+const createMockParsedURL = (hostname: string, queryParams: Record<string, string> = {}): ParsedURL => ({
+  scheme: 'myapp',
+  hostname,
+  path: '',
+  queryParams,
+});
+
+describe('useDeepLinking', () => {
+  let mockNavigationRef: NavigationRef;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockNavigationRef = {
+      isReady: jest.fn(() => true),
+      navigate: jest.fn(),
+      dispatch: jest.fn(),
+      getState: jest.fn(() => ({
+        key: 'root',
+        index: 0,
+        routeNames: ['Home'],
+        routes: [{ name: 'Home', key: 'home', params: undefined }],
+        type: 'stack' as const,
+        stale: false as const,
+      })),
+    } as unknown as NavigationRef;
+
+    mockLinking.getInitialURL = jest.fn().mockResolvedValue(null);
+    mockLinking.addEventListener.mockImplementation(() => ({
+      remove: jest.fn(),
+    }) as unknown as ReturnType<typeof Linking.addEventListener>);
+  });
+
+  test('ignores URLs with wrong hostname', async () => {
+    mockLinking.getInitialURL = jest.fn().mockResolvedValue('myapp://wrong/123');
+    mockLinking.parse.mockImplementation(() => createMockParsedURL('wrong', { listingId: '123' }));
+
+    renderHook(() => useDeepLinking(mockNavigationRef, true));
+
+    await waitFor(() => expect(mockLinking.getInitialURL).toHaveBeenCalled());
+    expect(mockNavigationRef.navigate).not.toHaveBeenCalled();
+  });
+
+  test('ignores URLs without listingId', async () => {
+    mockLinking.getInitialURL = jest.fn().mockResolvedValue('myapp://listing');
+    mockLinking.parse.mockImplementation(() => createMockParsedURL('listing'));
+
+    renderHook(() => useDeepLinking(mockNavigationRef, true));
+
+    await waitFor(() => expect(mockLinking.getInitialURL).toHaveBeenCalled());
+    expect(mockNavigationRef.navigate).not.toHaveBeenCalled();
+  });
+
+  test('navigates to LoginRequired when user is not logged in', async () => {
+    mockLinking.getInitialURL = jest.fn().mockResolvedValue('myapp://listing?listingId=123');
+    mockLinking.parse.mockImplementation(() => createMockParsedURL('listing', { listingId: '123' }));
+
+    renderHook(() => useDeepLinking(mockNavigationRef, false));
+
+    await waitFor(() => {
+      expect(mockNavigationRef.navigate).toHaveBeenCalledWith('LoginRequired');
+    });
+  });
+
+  test('navigates to NotFound when listing does not exist', async () => {
+    mockLinking.getInitialURL = jest.fn().mockResolvedValue('myapp://listing?listingId=999');
+    mockLinking.parse.mockImplementation(() => createMockParsedURL('listing', { listingId: '999' }));
+    mockFetch.mockResolvedValueOnce({ status: 404 } as Response);
+
+    renderHook(() => useDeepLinking(mockNavigationRef, true));
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledWith('/api/listings/999'));
+    await waitFor(() => expect(mockNavigationRef.navigate).toHaveBeenCalledWith('NotFound'));
+  });
+
+  test('navigates to ListingDetails when listing exists', async () => {
+    mockLinking.getInitialURL = jest.fn().mockResolvedValue('myapp://listing?listingId=123');
+    mockLinking.parse.mockImplementation(() => createMockParsedURL('listing', { listingId: '123' }));
+    mockFetch.mockResolvedValueOnce({ status: 200 } as Response);
+
+    renderHook(() => useDeepLinking(mockNavigationRef, true));
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledWith('/api/listings/123'));
+    await waitFor(() => expect(mockNavigationRef.navigate).toHaveBeenCalledWith('ListingDetails', { listingId: '123' }));
+  });
+
+  test('pushes to ListingDetails when already on ListingDetails screen', async () => {
+    mockNavigationRef.getState = jest.fn(() => ({
+      key: 'root',
+      index: 0,
+      routeNames: ['ListingDetails'],
+      routes: [{ name: 'ListingDetails', key: 'listingdetails', params: undefined }],
+      type: 'stack' as const,
+      stale: false as const,
+    }));
+    mockLinking.getInitialURL = jest.fn().mockResolvedValue('myapp://listing?listingId=123');
+    mockLinking.parse.mockImplementation(() => createMockParsedURL('listing', { listingId: '123' }));
+    mockFetch.mockResolvedValueOnce({ status: 200 } as Response);
+
+    renderHook(() => useDeepLinking(mockNavigationRef, true));
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledWith('/api/listings/123'));
+    await waitFor(() => {
+      expect(mockNavigationRef.dispatch).toHaveBeenCalledWith(
+        StackActions.push('ListingDetails', { listingId: '123' })
+      );
+    });
+    expect(mockNavigationRef.navigate).not.toHaveBeenCalled();
+  });
+});

--- a/ths-test-app/src/hooks/__tests__/useListings.test.ts
+++ b/ths-test-app/src/hooks/__tests__/useListings.test.ts
@@ -1,0 +1,89 @@
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+import { useListings } from '../useListings';
+
+global.fetch = jest.fn();
+
+const mockFetch = fetch as jest.MockedFunction<typeof fetch>;
+
+describe('useListings', () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+  });
+
+  test('returns initial state', () => {
+    const { result } = renderHook(() => useListings());
+
+    expect(result.current.listingData).toEqual([]);
+    expect(result.current.listing).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(typeof result.current.getAllListings).toBe('function');
+    expect(typeof result.current.getListingById).toBe('function');
+  });
+
+  test('getAllListings fetches and updates listingData', async () => {
+    const mockListings = [
+      { id: '1', title: 'Listing 1' },
+      { id: '2', title: 'Listing 2' },
+    ];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockListings,
+    } as Response);
+
+    const { result } = renderHook(() => useListings());
+
+    act(() => {
+      result.current.getAllListings();
+    });
+
+    await waitFor(() => {
+      expect(result.current.listingData).toEqual(mockListings);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/listings');
+  });
+
+  test('getListingById fetches and updates listing on success', async () => {
+    const mockListing = {
+      id: '1',
+      title: 'Test Listing',
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockListing,
+    } as Response);
+
+    const { result } = renderHook(() => useListings());
+
+    act(() => {
+      result.current.getListingById('1');
+    });
+
+    await waitFor(() => {
+      expect(result.current.listing).toEqual(mockListing);
+      expect(result.current.error).toBeNull();
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/listings/1');
+  });
+
+  test('getListingById handles errors', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    } as Response);
+
+    const { result } = renderHook(() => useListings());
+
+    act(() => {
+      result.current.getListingById('999');
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBe('not_found');
+      expect(result.current.listing).toBeNull();
+    });
+  });
+});

--- a/ths-test-app/src/hooks/useDeepLinking.ts
+++ b/ths-test-app/src/hooks/useDeepLinking.ts
@@ -1,0 +1,75 @@
+import { useEffect } from 'react';
+import * as Linking from 'expo-linking';
+import {
+  NavigationContainerRef,
+  StackActions,
+} from '@react-navigation/native';
+
+type NavigationRef = NavigationContainerRef<ReactNavigation.RootParamList>;
+
+function navigateOrPushToListingDetails(
+  navigationRef: NavigationRef,
+  listingId: string
+) {
+  const state = navigationRef.getState();
+  const currentRoute = state?.routes[state.index];
+
+  if (currentRoute?.name === 'ListingDetails') {
+    navigationRef.dispatch(StackActions.push('ListingDetails', { listingId }));
+  } else {
+    navigationRef.navigate('ListingDetails', { listingId });
+  }
+}
+
+export function useDeepLinking(navigationRef: NavigationRef, isLoggedIn: boolean) {
+
+  useEffect(() => {
+    const handleDeepLink = async (url: string | null) => {
+      if (!url) return;
+
+      const parsed = Linking.parse(url);
+      const { hostname, queryParams } = parsed;
+
+      if (hostname !== 'listing' || !queryParams?.listingId) {
+        return;
+      }
+
+      if (!navigationRef.isReady()) {
+        return;
+      }
+
+      const listingId = queryParams.listingId as string;
+      if (!listingId) {
+        return;
+      }
+
+      if (!isLoggedIn) {
+        navigationRef.navigate('LoginRequired');
+        return;
+      }
+
+      try {
+        const response = await fetch(`/api/listings/${listingId}`);
+        if (response.status === 404) {
+          navigationRef.navigate('NotFound');
+          return;
+        }
+
+        navigateOrPushToListingDetails(navigationRef, listingId);
+      } catch (error) {
+        console.error('Deep linking error:', error);
+      }
+    };
+
+    Linking.getInitialURL().then(handleDeepLink);
+
+    const subscription = Linking.addEventListener('url', (event) => {
+      handleDeepLink(event.url);
+    });
+
+    return () => {
+      subscription.remove();
+    };
+
+  }, [navigationRef, isLoggedIn]);
+}

--- a/ths-test-app/src/hooks/useListings.ts
+++ b/ths-test-app/src/hooks/useListings.ts
@@ -1,0 +1,48 @@
+import { useState } from "react";
+
+export interface Listing {
+  id: string;
+  title: string;
+}
+
+export function useListings() {
+  const [listingData, setListingData] = useState<Listing[]>([]);
+  const [listingState, setListingState] = useState<{ listing: any; error: string | null }>({
+    listing: null,
+    error: null,
+  });
+
+  const getAllListings = () => {
+    fetch("/api/listings")
+      .then(response => response.json())
+      .then(data => setListingData(data));
+  };
+
+  const getListingById = (id: string) => {
+    setListingState({ listing: null, error: null });
+    fetch(`/api/listings/${id}`)
+      .then(response => {
+        if (!response.ok) {
+          if (response.status === 404) {
+            throw new Error('not_found');
+          }
+          throw new Error('network_error');
+        }
+        return response.json();
+      })
+      .then(data => {
+        setListingState({ listing: data, error: null });
+      })
+      .catch(err => {
+        setListingState({ listing: null, error: err.message || 'network_error' });
+      });
+  };
+
+  return {
+    listingData,
+    listing: listingState.listing,
+    error: listingState.error,
+    getAllListings,
+    getListingById
+  };
+}

--- a/ths-test-app/src/mocks/handlers.js
+++ b/ths-test-app/src/mocks/handlers.js
@@ -535,6 +535,9 @@ const handlers = [
       return HttpResponse.json({ error: "Listing not found" }, { status: 404 });
     }
   }),
+  http.post("/symbolicate", () => {
+    return HttpResponse.json({});
+  }),
 ];
 
 export default handlers;

--- a/ths-test-app/src/navigation/index.tsx
+++ b/ths-test-app/src/navigation/index.tsx
@@ -5,6 +5,8 @@ import { Platform } from 'react-native';
 
 import HomeScreen from './screens/Home';
 import Listings from './screens/Listings';
+import ListingDetails from './screens/ListingDetails';
+import LoginRequired from './screens/LoginRequired';
 import NotFound from './screens/NotFound';
 
 import { HapticTab } from '../components/HapticTab';
@@ -50,6 +52,22 @@ const RootStack = createNativeStackNavigator({
         headerShown: false,
       },
     },
+    ListingDetails: {
+      screen: ListingDetails,
+      options: {
+        title: 'Listing Details',
+      },
+      linking: {
+        path: 'listing',
+        exact: true,
+      },
+    },
+    LoginRequired: {
+      screen: LoginRequired,
+      options: {
+        title: 'Login Required',
+      },
+    },
     NotFound: {
       screen: NotFound,
       options: {
@@ -68,7 +86,9 @@ type RootStackParamList = StaticParamList<typeof RootStack>;
 
 declare global {
   namespace ReactNavigation {
-    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-    interface RootParamList extends RootStackParamList {}
+    interface RootParamList extends RootStackParamList {
+      ListingDetails: { id?: string; listingId?: string };
+      [key: string]: object | undefined;
+    }
   }
 }

--- a/ths-test-app/src/navigation/screens/ListingDetails.tsx
+++ b/ths-test-app/src/navigation/screens/ListingDetails.tsx
@@ -1,0 +1,89 @@
+import { useContext, useEffect } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { RouteProp, useRoute } from '@react-navigation/native';
+
+import { LoggedInContext } from '@/App';
+import { getAnimalDisplay } from '@/helpers/getAnimalDisplay';
+import { useListings } from '@/hooks/useListings';
+
+export default function ListingDetailsScreen() {
+  const route = useRoute<RouteProp<ReactNavigation.RootParamList, 'ListingDetails'>>();
+  const { isLoggedIn } = useContext(LoggedInContext);
+
+  const id = route.params?.listingId ?? route.params?.id;
+  const { getListingById, listing } = useListings();
+
+  useEffect(() => {
+    if (isLoggedIn && id) {
+      getListingById(id);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, isLoggedIn]);
+
+  if (!isLoggedIn) {
+    return (
+      <View style={styles.errorContainer}>
+        <Text style={styles.title}>Login Required</Text>
+        <Text style={styles.subtitle}>Please log in to view this listing.</Text>
+      </View>
+    );
+  }
+
+  if (!listing) {
+    return (
+      <View style={styles.errorContainer}>
+        <Text style={styles.subtitle}>Loading...</Text>
+      </View>
+    );
+  }
+
+  const animals = listing.animals || [];
+  const { totalCount, icons } = getAnimalDisplay(animals);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.headerContainer}>
+        <Text style={styles.title}>
+          {listing.user?.firstName}
+        </Text>
+      </View>
+
+      <Text style={styles.title}>{listing.title}</Text>
+      <Text style={styles.subtitle}>
+        {listing.location?.name}, {listing.location?.countryName}
+      </Text>
+      {animals.length > 0 && (
+        <Text style={styles.subtitle}>
+          {totalCount} {icons}
+        </Text>
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+  },
+  errorContainer: {
+    flex: 1,
+    padding: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  headerContainer: {
+    alignItems: 'flex-end',
+    paddingBottom: 25,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 8,
+    color: '#153839',
+  },
+  subtitle: {
+    fontSize: 16,
+    marginBottom: 16,
+  },
+});

--- a/ths-test-app/src/navigation/screens/Listings.tsx
+++ b/ths-test-app/src/navigation/screens/Listings.tsx
@@ -1,34 +1,43 @@
-import { useEffect, useState } from "react";
-import { Text, View, StyleSheet, FlatList } from "react-native";
-import {
-  useSafeAreaInsets,
-} from 'react-native-safe-area-context';
+import { useContext, useEffect } from 'react';
+import { FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
+import { NavigationProp, useNavigation } from '@react-navigation/native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-interface Listing {
-  id: number;
-  title: string;
-}
+import { LoggedInContext } from '@/App';
+import { useListings } from '@/hooks/useListings';
+import LoginRequiredScreen from './LoginRequired';
 
-const ListingRow = ({title}: {title: string}) => (
-  <View style={styles.item}>
-    <Text style={styles.title}>{title}</Text>
-  </View>
-);
+const ListingRow = ({id, title}: {id: string, title: string}) => {
+  const navigation = useNavigation<NavigationProp<ReactNavigation.RootParamList>>();
+
+  return (
+    <Pressable onPress={() => navigation.navigate('ListingDetails', { id })} style={styles.item}>
+      <Text style={styles.title}>{title}</Text>
+    </Pressable>
+  );
+};
 
 export default function ListingsScreen() {
-  const [ listingData, setListingData ] = useState<Listing[]>([]);
+  const { listingData, getAllListings } = useListings();
   const insets = useSafeAreaInsets();
+  const { isLoggedIn } = useContext(LoggedInContext);
 
   useEffect(() => {
-      fetch("/api/listings").then(response => response.json()).then(data => setListingData(data));
-  }, []);
-  
+    if (isLoggedIn) {
+      getAllListings();
+    }
+  }, [getAllListings, isLoggedIn]);
+
+  if (!isLoggedIn) {
+    return <LoginRequiredScreen />;
+  }
+
   return (
-    <View style={[styles.container, { paddingTop: insets.top }]}>
+    <View style={[styles.container, { paddingTop: insets.top, paddingBottom: insets.bottom + 60 }]}>
       <FlatList
         data={listingData}
-        keyExtractor={(item) => item.id.toString()}
-        renderItem={({item}) => <ListingRow title={item.title} />}
+        keyExtractor={(item) => item.id}
+        renderItem={({item}) => <ListingRow id={item.id} title={item.title} />}
         style={styles.list}
       />
     </View>

--- a/ths-test-app/src/navigation/screens/LoginRequired.tsx
+++ b/ths-test-app/src/navigation/screens/LoginRequired.tsx
@@ -3,13 +3,13 @@ import {
   useSafeAreaInsets,
 } from 'react-native-safe-area-context';
 
-export default function NotFoundScreen() {
+export default function LoginRequiredScreen() {
   const insets = useSafeAreaInsets();
-  
+
   return (
     <View style={[styles.container, { paddingBottom: insets.bottom }]}>
-      <Text style={styles.title}>404 - Not Found</Text>
-      <Text style={styles.subtitle}>The page you are looking for does not exist.</Text>
+      <Text style={styles.title}>Login Required</Text>
+      <Text style={styles.subtitle}>Please log in to view this listing.</Text>
     </View>
   );
 }

--- a/ths-test-app/src/navigation/screens/__tests__/ListingDetails.test.tsx
+++ b/ths-test-app/src/navigation/screens/__tests__/ListingDetails.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import ListingDetailsScreen from '../ListingDetails';
+import { LoggedInContext } from '../../../App';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { useListings } from '../../../hooks/useListings';
+import { useRoute, RouteProp } from '@react-navigation/native';
+
+jest.mock('../../../hooks/useListings');
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useRoute: jest.fn(),
+}));
+
+const mockUseListings = useListings as jest.MockedFunction<typeof useListings>;
+const mockUseRoute = useRoute as jest.MockedFunction<typeof useRoute>;
+
+type ListingDetailsRoute = RouteProp<ReactNavigation.RootParamList, 'ListingDetails'>;
+
+const createMockRoute = (params?: { id?: string; listingId?: string }): ListingDetailsRoute => {
+  return {
+    key: 'test-route',
+    name: 'ListingDetails',
+    params,
+  } as ListingDetailsRoute;
+};
+
+const renderWithContext = (component: React.ReactNode, isLoggedIn = false) => {
+  return render(
+    <SafeAreaProvider>
+      <LoggedInContext.Provider value={{ isLoggedIn, toggleIsLoggedIn: jest.fn() }}>
+        {component}
+      </LoggedInContext.Provider>
+    </SafeAreaProvider>
+  );
+};
+
+test('renders Login Required when not logged in', () => {
+  mockUseRoute.mockReturnValue(createMockRoute({ id: '1' }));
+
+  mockUseListings.mockReturnValue({
+    listingData: [],
+    listing: null,
+    error: null,
+    getAllListings: jest.fn(),
+    getListingById: jest.fn(),
+  });
+
+  renderWithContext(<ListingDetailsScreen />, false);
+  
+  const loginRequiredText = screen.getByText('Login Required');
+  expect(loginRequiredText).toBeTruthy();
+});
+
+test('renders Loading when logged in but no listing', () => {
+  mockUseRoute.mockReturnValue(createMockRoute({ id: '1' }));
+
+  mockUseListings.mockReturnValue({
+    listingData: [],
+    listing: null,
+    error: null,
+    getAllListings: jest.fn(),
+    getListingById: jest.fn(),
+  });
+
+  renderWithContext(<ListingDetailsScreen />, true);
+  
+  const loadingText = screen.getByText('Loading...');
+  expect(loadingText).toBeTruthy();
+});
+
+test('calls getListingById when logged in and id is present', () => {
+  const getListingById = jest.fn();
+  mockUseRoute.mockReturnValue(createMockRoute({ id: '1' }));
+
+  mockUseListings.mockReturnValue({
+    listingData: [],
+    listing: null,
+    error: null,
+    getAllListings: jest.fn(),
+    getListingById,
+  });
+
+  renderWithContext(<ListingDetailsScreen />, true);
+  
+  expect(getListingById).toHaveBeenCalledWith('1');
+});
+
+test('calls getListingById when logged in and listingId is present', () => {
+  const getListingById = jest.fn();
+  mockUseRoute.mockReturnValue(createMockRoute({ listingId: '2' }));
+
+  mockUseListings.mockReturnValue({
+    listingData: [],
+    listing: null,
+    error: null,
+    getAllListings: jest.fn(),
+    getListingById,
+  });
+
+  renderWithContext(<ListingDetailsScreen />, true);
+  
+  expect(getListingById).toHaveBeenCalledWith('2');
+});
+
+test('renders listing details when listing is available', () => {
+  const mockListing = {
+    id: '1',
+    title: 'Test Listing',
+    user: { firstName: 'John' },
+    location: { name: 'London', countryName: 'UK' },
+    animals: [{ name: 'dog', count: 2 }],
+  };
+
+  mockUseRoute.mockReturnValue(createMockRoute({ id: '1' }));
+
+  mockUseListings.mockReturnValue({
+    listingData: [],
+    listing: mockListing,
+    error: null,
+    getAllListings: jest.fn(),
+    getListingById: jest.fn(),
+  });
+
+  renderWithContext(<ListingDetailsScreen />, true);
+  
+  expect(screen.getByText('John')).toBeTruthy();
+  expect(screen.getByText('Test Listing')).toBeTruthy();
+  expect(screen.getByText('London, UK')).toBeTruthy();
+  expect(screen.getByText(/2/)).toBeTruthy();
+});

--- a/ths-test-app/src/navigation/screens/__tests__/Listings.test.tsx
+++ b/ths-test-app/src/navigation/screens/__tests__/Listings.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render, screen, userEvent } from '@testing-library/react-native';
+import ListingsScreen from '../Listings';
+import { LoggedInContext } from '../../../App';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { useListings } from '../../../hooks/useListings';
+import { useNavigation } from '@react-navigation/native';
+
+jest.mock('../../../hooks/useListings');
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: jest.fn(),
+}));
+
+const mockUseListings = useListings as jest.MockedFunction<typeof useListings>;
+const mockUseNavigation = useNavigation as jest.MockedFunction<typeof useNavigation>;
+
+const renderWithContext = (component: React.ReactNode, isLoggedIn = false) => {
+  return render(
+    <SafeAreaProvider>
+      <LoggedInContext.Provider value={{ isLoggedIn, toggleIsLoggedIn: jest.fn() }}>
+        {component}
+      </LoggedInContext.Provider>
+    </SafeAreaProvider>
+  );
+};
+
+test('renders LoginRequiredScreen when not logged in', () => {
+  mockUseListings.mockReturnValue({
+    listingData: [],
+    listing: null,
+    error: null,
+    getAllListings: jest.fn(),
+    getListingById: jest.fn(),
+  });
+
+  renderWithContext(<ListingsScreen />, false);
+  
+  const loginRequiredText = screen.getByText('Login Required');
+  expect(loginRequiredText).toBeTruthy();
+});
+
+test('calls getAllListings when logged in', () => {
+  const getAllListings = jest.fn();
+  mockUseListings.mockReturnValue({
+    listingData: [],
+    listing: null,
+    error: null,
+    getAllListings,
+    getListingById: jest.fn(),
+  });
+
+  renderWithContext(<ListingsScreen />, true);
+  
+  expect(getAllListings).toHaveBeenCalled();
+});
+
+test('renders listing items when logged in', () => {
+  const mockListings = [
+    { id: '1', title: 'Test Listing 1' },
+    { id: '2', title: 'Test Listing 2' },
+  ];
+
+  mockUseListings.mockReturnValue({
+    listingData: mockListings,
+    listing: null,
+    error: null,
+    getAllListings: jest.fn(),
+    getListingById: jest.fn(),
+  });
+
+  const mockNavigate = jest.fn();
+  mockUseNavigation.mockReturnValue({
+    navigate: mockNavigate,
+  } as any);
+
+  renderWithContext(<ListingsScreen />, true);
+  
+  expect(screen.getByText('Test Listing 1')).toBeTruthy();
+  expect(screen.getByText('Test Listing 2')).toBeTruthy();
+});
+
+test('navigates to ListingDetails when listing is pressed', async () => {
+  const mockListings = [
+    { id: '1', title: 'Test Listing 1' },
+  ];
+
+  mockUseListings.mockReturnValue({
+    listingData: mockListings,
+    listing: null,
+    error: null,
+    getAllListings: jest.fn(),
+    getListingById: jest.fn(),
+  });
+
+  const mockNavigate = jest.fn();
+  mockUseNavigation.mockReturnValue({
+    navigate: mockNavigate,
+  } as any);
+
+  const user = userEvent.setup();
+  renderWithContext(<ListingsScreen />, true);
+  
+  const listingItem = screen.getByText('Test Listing 1');
+  await user.press(listingItem);
+  
+  expect(mockNavigate).toHaveBeenCalledWith('ListingDetails', { id: '1' });
+});

--- a/ths-test-app/tsconfig.json
+++ b/ths-test-app/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "strict": true,
     "moduleResolution": "bundler",
+    "jsx": "react-native",
     "paths": {
       "@/*": [
         "./src/*"


### PR DESCRIPTION
## Evie Polden Tech Test

This PR adds additional navigation and deep linking functionality to an existing app. I have made sure to keep the solution simple and easy to extend, pulling out functionality into helper or smaller component files where appropriate, and ensuring get/set functionality lives within a centralised hook.

### What's included
**Individual Listing Screen**
- I have made the entries on the Listings screen pressable, and they now navigate to their own listings screen.
- I have safely handled error/loading states for if the user is not logged in, or if the data is unable to be fetched from the server.

**Authenticated Navigation**
- The Listings and Listing Details screens are now only accessible when the user is logged in.

**Deep Linking**
- Configured support for links such as `ths-test-app://listing?listingId=123456`.
- The app correctly opens the relevant listing screen when launched from a URL.
- Opening a listing link while already on a listing screen pushes a new instance onto the stack.

**Minor Improvements**
- I fixed a UI bug on the Listings screen where the bottom of the list wasn't accessible. I added extra padding so the user can now scroll down to the final entries.

### Testing
**Unit Tests**
I have added React Native Testing Library tests for both the new screens added, and the hooks. These can be run using `npm test`.

**Manual Testing**
I have manually tested the app's deep linking functionality using the following command.

```
xcrun simctl openurl booted "thstestapp://listing?listingId=475198"
```

### Notes and Trade-Offs
- I reworked some of the existing files in order to make the entire task more reusable. I really like splitting up work more granularly, such as using Atomic Design, but that would have felt excessive for such a small code base, and out of scope.
- If I had more time I would have made the error states more robust, both in terms of when accessing the data from the hook (which I simplified due to the API being hard-coded) and improving the user's experience.
- The Listing Details pages are quite bare. I tried to present the data I had as best I could, in line with the current Trusted Housesitters app, but ideally the UI would be more appealing too.