### PR TITLE
refactor: infrastructure update devcontainer workspace to mount not copy

### DIFF
--- a/infrastructure/.devcontainer/Dockerfile
+++ b/infrastructure/.devcontainer/Dockerfile
@@ -12,10 +12,6 @@ ENV PATH="/root/.pulumi/bin:${PATH}"
 
 # Working directory
 WORKDIR /workspace
-COPY . /workspace/
-
-# Symlink so Pylance can statically resolve the pm_infra module (mapped from package/ in pyproject.toml)
-RUN ln -s /workspace/infrastructure/package /workspace/infrastructure/pm_infra
 
 # Install the shared package and create venvs for each stack
 RUN pip install --no-cache-dir pulumi pulumi-aws pydantic
@@ -24,22 +20,6 @@ RUN pip install --no-cache-dir pulumi pulumi-aws pydantic
 RUN AWS_VER=$(pip show pulumi-aws | awk '/^Version:/{print $2}') && \
     pulumi plugin install resource aws "$AWS_VER"
 
-# Pre-create venvs for all stacks so candidates don't wait
-RUN for dir in network cache-service search; do \
-    cd /workspace/infrastructure/$dir && \
-    python -m venv venv && \
-    venv/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    venv/bin/pip install --no-cache-dir -r requirements.txt && \
-    cd /workspace; \
-    done
-
-# Verify the shared package is importable
-RUN cd /workspace/infrastructure/search && \
-    venv/bin/python -c "from pm_infra.components.elasticache import ElastiCache; print('pm_infra OK')"
-
 # Local Pulumi backend (no cloud account needed)
 ENV PULUMI_BACKEND_URL="file://~/.pulumi-local"
 ENV PULUMI_CONFIG_PASSPHRASE=""
-
-# Seed local Pulumi backend with mock network stack + dummy AWS profiles
-RUN .devcontainer/seed/seed_stacks.sh

--- a/infrastructure/.devcontainer/devcontainer.json
+++ b/infrastructure/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
     "dockerfile": "Dockerfile",
     "context": ".."
   },
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/infrastructure/.devcontainer/setup.sh
+++ b/infrastructure/.devcontainer/setup.sh
@@ -3,6 +3,36 @@ set -e
 
 echo "=== PetMatch Infrastructure Assessment ==="
 echo ""
+
+# Symlink so Pylance can statically resolve the pm_infra module
+if [ ! -e "/workspace/infrastructure/pm_infra" ]; then
+    ln -s /workspace/infrastructure/package /workspace/infrastructure/pm_infra
+fi
+
+# Create venvs for all stacks
+for dir in network cache-service search; do
+    if [ ! -d "/workspace/infrastructure/$dir/venv" ]; then
+        echo "Creating venv for $dir..."
+        cd /workspace/infrastructure/$dir
+        python -m venv venv
+        venv/bin/pip install -q --upgrade pip setuptools wheel
+        venv/bin/pip install -q -r requirements.txt
+        cd /workspace
+    fi
+done
+
+# Verify the shared package is importable
+cd /workspace/infrastructure/search
+venv/bin/python -c "from pm_infra.components.elasticache import ElastiCache; print('pm_infra OK')"
+cd /workspace
+
+# Seed Pulumi stacks if needed
+if ! pulumi stack ls --project network 2>/dev/null | grep -q "test.eu-west-1"; then
+    echo "Seeding Pulumi stacks..."
+    /workspace/.devcontainer/seed/seed_stacks.sh
+fi
+
+echo ""
 echo "Key locations:"
 echo "  ElastiCache component:  infrastructure/package/components/elasticache/elasticache.py"
 echo "  Cache service stack:    infrastructure/cache-service/__main__.py"
@@ -13,22 +43,4 @@ echo "  cd infrastructure/search"
 echo "  source venv/bin/activate"
 echo "  pulumi preview --stack organization/search/test.eu-west-1"
 echo ""
-
-# Ensure venvs exist
-for dir in network cache-service search; do
-    if [ ! -d "/workspace/infrastructure/$dir/venv" ]; then
-        echo "Creating venv for $dir..."
-        cd /workspace/infrastructure/$dir
-        python -m venv venv
-        venv/bin/pip install -q -r requirements.txt
-        cd /workspace
-    fi
-done
-
-# Re-seed stacks if needed (e.g. if container was rebuilt without image cache)
-if ! pulumi stack ls --project network 2>/dev/null | grep -q "test.eu-west-1"; then
-    echo "Re-seeding Pulumi stacks..."
-    /workspace/.devcontainer/seed/seed_stacks.sh
-fi
-
 echo "Ready."

--- a/infrastructure/infrastructure/pm_infra
+++ b/infrastructure/infrastructure/pm_infra
@@ -1,0 +1,1 @@
+/workspace/infrastructure/package


### PR DESCRIPTION
Bind-mount repo into devcontainer instead of copying

Switches the infrastructure devcontainer from COPY into the image to mount the workspace, so file edits are synced. Setup (symlink, venvs, stack seeding) moves from the Dockerfile to `postCreateCommand`.